### PR TITLE
@hustler fix typo in CheckRecruiterExistsV2 soap template

### DIFF
--- a/lib/soap-templates/CheckRecruiterExistsV2.hbs
+++ b/lib/soap-templates/CheckRecruiterExistsV2.hbs
@@ -4,7 +4,7 @@
       <job:CheckRecruiterExistsV2>
          <job:sRecruiterName>{{recruiterName}}</job:sRecruiterName>
          <job:sCustomerBillingId>{{customerBillingId}}</job:sCustomerBillingId>
-         <job:sMadgexID>{{madgexID}}</job:sMadgexID>
+         <job:smadgexId>{{madgexID}}</job:smadgexId>
       </job:CheckRecruiterExistsV2>
    </soapenv:Body>
 </soapenv:Envelope>


### PR DESCRIPTION
Fixes typo in template. Could not search by madgex Id. 